### PR TITLE
feat: fly-to-cart UX — quantity stepper + dot animation

### DIFF
--- a/backend/GoldenFreshCart.API/Program.cs
+++ b/backend/GoldenFreshCart.API/Program.cs
@@ -13,23 +13,31 @@ builder.WebHost.UseUrls($"http://0.0.0.0:{port}");
 builder.Services.AddControllers();
 builder.Services.AddEndpointsApiExplorer();
 
-// Connect to PostgreSQL (Supabase)
-// Railway sets DATABASE_URL as a URI — we parse it into key=value format for Npgsql
-// Local dev uses DefaultConnection from appsettings.json (already in key=value format)
-var databaseUrl = Environment.GetEnvironmentVariable("DATABASE_URL");
-builder.Services.AddDbContext<AppDbContext>(options =>
+// Connect to PostgreSQL (Supabase/Railway)
+// Priority: DATABASE_URL env var (Railway) → DefaultConnection in appsettings (local dev)
+// Both URI format (postgresql://user:pass@host/db) and key=value format are supported
+static string ParseConnectionString(string raw)
 {
-    string connStr;
-    if (!string.IsNullOrEmpty(databaseUrl))
+    // If it looks like a URI, convert it to Npgsql key=value format
+    if (raw.StartsWith("postgresql://") || raw.StartsWith("postgres://"))
     {
-        var uri = new Uri(databaseUrl);
+        var uri = new Uri(raw);
         var userInfo = uri.UserInfo.Split(':');
-        connStr = $"Host={uri.Host};Port={uri.Port};Database={uri.AbsolutePath.TrimStart('/')};Username={userInfo[0]};Password={userInfo[1]};SSL Mode=Require;Trust Server Certificate=true";
+        return $"Host={uri.Host};Port={uri.Port};Database={uri.AbsolutePath.TrimStart('/')};Username={userInfo[0]};Password={userInfo[1]};SSL Mode=Require;Trust Server Certificate=true";
     }
-    else
-        connStr = builder.Configuration.GetConnectionString("DefaultConnection")!;
-    options.UseNpgsql(connStr);
-});
+    // Already in key=value format — use as-is
+    return raw;
+}
+
+var databaseUrl = Environment.GetEnvironmentVariable("DATABASE_URL")
+    ?? builder.Configuration.GetConnectionString("DefaultConnection");
+
+if (string.IsNullOrWhiteSpace(databaseUrl))
+    throw new InvalidOperationException(
+        "No database connection string found. Set DATABASE_URL env var or DefaultConnection in appsettings.json.");
+
+builder.Services.AddDbContext<AppDbContext>(options =>
+    options.UseNpgsql(ParseConnectionString(databaseUrl)));
 
 // Read the JWT secret key from appsettings.json — used to sign and verify tokens
 // If you change the key, all existing tokens become invalid (users will be logged out)

--- a/frontend/src/components/layout/Navbar.tsx
+++ b/frontend/src/components/layout/Navbar.tsx
@@ -45,7 +45,9 @@ export default function Navbar() {
           {/* Right side: cart button + auth actions */}
           <div className="flex items-center gap-3">
             {/* Cart icon with item count badge */}
+            {/* id used by ProductCard to find this element's position for the fly-to-cart animation */}
             <button
+              id="cart-icon-btn"
               type="button"
               onClick={openCart}
               className="relative p-2 rounded-xl hover:bg-cream-100 transition-colors"

--- a/frontend/src/components/product/ProductCard.tsx
+++ b/frontend/src/components/product/ProductCard.tsx
@@ -1,3 +1,4 @@
+import { useRef, useState } from 'react';
 import type { Product } from '../../types';
 import { useCartStore } from '../../store/cartStore';
 
@@ -5,13 +6,71 @@ interface Props {
   product: Product;
 }
 
+// Launches a small dot that flies from the Add button to the cart icon in the navbar.
+// Uses native DOM + CSS transitions — no animation library needed.
+function flyToCart(fromEl: HTMLElement) {
+  const cartBtn = document.getElementById('cart-icon-btn');
+  if (!cartBtn) return;
+
+  const fromRect = fromEl.getBoundingClientRect();
+  const toRect = cartBtn.getBoundingClientRect();
+
+  // Starting position: center of the Add button
+  const startX = fromRect.left + fromRect.width / 2;
+  const startY = fromRect.top + fromRect.height / 2;
+
+  // Ending position: center of the cart icon button
+  const endX = toRect.left + toRect.width / 2;
+  const endY = toRect.top + toRect.height / 2;
+
+  // Create a small green circle fixed at the start position
+  const dot = document.createElement('div');
+  dot.style.cssText = `
+    position: fixed;
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    background: #3d6b45;
+    left: ${startX - 6}px;
+    top: ${startY - 6}px;
+    pointer-events: none;
+    z-index: 9999;
+    transition: transform 0.55s cubic-bezier(0.25, 0.46, 0.45, 0.94), opacity 0.55s ease;
+    opacity: 1;
+  `;
+  document.body.appendChild(dot);
+
+  // Trigger the transition on next frame so the browser registers the start state first
+  requestAnimationFrame(() => {
+    dot.style.transform = `translate(${endX - startX}px, ${endY - startY}px) scale(0.4)`;
+    dot.style.opacity = '0';
+  });
+
+  // Remove the dot from the DOM after the animation completes
+  dot.addEventListener('transitionend', () => dot.remove(), { once: true });
+}
+
 export default function ProductCard({ product }: Props) {
-  const { addItem, openCart } = useCartStore();
+  const { addItem } = useCartStore();
+
+  // Local quantity state — resets to 1 after each add
+  const [qty, setQty] = useState(1);
+
+  // Ref on the Add button so we can read its screen position for the animation
+  const addBtnRef = useRef<HTMLButtonElement>(null);
 
   const handleAdd = () => {
-    addItem(product);
-    openCart();
+    // Add product with the chosen quantity — sidebar does NOT open automatically
+    addItem(product, qty);
+
+    // Trigger the fly-to-cart dot animation
+    if (addBtnRef.current) flyToCart(addBtnRef.current);
+
+    // Reset quantity back to 1 after adding
+    setQty(1);
   };
+
+  const isOutOfStock = product.stock === 0;
 
   return (
     <div className="card group flex flex-col overflow-hidden">
@@ -26,7 +85,7 @@ export default function ProductCard({ product }: Props) {
             Only {product.stock} left
           </span>
         )}
-        {product.stock === 0 && (
+        {isOutOfStock && (
           <div className="absolute inset-0 bg-white/70 flex items-center justify-center">
             <span className="badge bg-red-100 text-red-600 text-sm">Out of Stock</span>
           </div>
@@ -42,22 +101,70 @@ export default function ProductCard({ product }: Props) {
         </h3>
         <p className="text-forest-500 text-xs mb-3 line-clamp-2">{product.description}</p>
 
-        <div className="flex items-center justify-between mt-auto">
-          <div>
-            <span className="font-display font-bold text-lg text-forest-700">
-              kr {product.price.toFixed(0)}
-            </span>
-            <span className="text-forest-400 text-xs ml-1">/ {product.unit}</span>
+        {/* Price row */}
+        <div className="mb-3">
+          <span className="font-display font-bold text-lg text-forest-700">
+            kr {product.price.toFixed(0)}
+          </span>
+          <span className="text-forest-400 text-xs ml-1">/ {product.unit}</span>
+        </div>
+
+        {/* Quantity stepper + Add button row — hidden when out of stock */}
+        {!isOutOfStock && (
+          <div className="flex items-center justify-between gap-2 mt-auto">
+            {/* Quantity stepper: − qty + */}
+            <div className="flex items-center gap-1">
+              <button
+                type="button"
+                onClick={() => setQty(q => Math.max(1, q - 1))}
+                disabled={qty <= 1}
+                aria-label="Decrease quantity"
+                className="w-7 h-7 rounded-lg border border-forest-200 text-forest-600 font-bold
+                           flex items-center justify-center hover:bg-cream-100 transition-colors
+                           disabled:opacity-30 disabled:cursor-not-allowed"
+              >
+                −
+              </button>
+              <span className="w-6 text-center text-sm font-medium text-forest-700">
+                {qty}
+              </span>
+              <button
+                type="button"
+                onClick={() => setQty(q => Math.min(product.stock, q + 1))}
+                disabled={qty >= product.stock}
+                aria-label="Increase quantity"
+                className="w-7 h-7 rounded-lg border border-forest-200 text-forest-600 font-bold
+                           flex items-center justify-center hover:bg-cream-100 transition-colors
+                           disabled:opacity-30 disabled:cursor-not-allowed"
+              >
+                +
+              </button>
+            </div>
+
+            {/* Add button — triggers fly animation, does NOT open cart sidebar */}
+            <button
+              ref={addBtnRef}
+              type="button"
+              onClick={handleAdd}
+              className="bg-forest-600 hover:bg-forest-700 text-white text-sm font-medium
+                         px-4 py-2 rounded-xl transition-all active:scale-95"
+            >
+              Add
+            </button>
           </div>
+        )}
+
+        {/* Disabled Add button when out of stock */}
+        {isOutOfStock && (
           <button
-            onClick={handleAdd}
-            disabled={product.stock === 0}
-            className="bg-forest-600 hover:bg-forest-700 disabled:opacity-40 disabled:cursor-not-allowed
-                       text-white text-sm font-medium px-4 py-2 rounded-xl transition-all active:scale-95"
+            type="button"
+            disabled
+            className="mt-auto bg-forest-600 opacity-40 cursor-not-allowed
+                       text-white text-sm font-medium px-4 py-2 rounded-xl"
           >
             Add
           </button>
-        </div>
+        )}
       </div>
     </div>
   );

--- a/frontend/src/store/cartStore.ts
+++ b/frontend/src/store/cartStore.ts
@@ -7,7 +7,7 @@ import type { CartItem, Product } from '../types';
 interface CartState {
   items: CartItem[];
   isOpen: boolean;           // Controls whether the CartSidebar panel is visible
-  addItem: (product: Product) => void;
+  addItem: (product: Product, qty?: number) => void;
   removeItem: (productId: number) => void;
   updateQty: (productId: number, qty: number) => void;
   clearCart: () => void;
@@ -21,18 +21,18 @@ export const useCartStore = create<CartState>((set, get) => ({
   items: [],
   isOpen: false,
 
-  // If the product is already in the cart, increment its quantity
-  // Otherwise, add it as a new item with quantity 1
-  addItem: (product) => {
+  // If the product is already in the cart, increment its quantity by qty (default 1)
+  // Otherwise, add it as a new item with the given qty
+  addItem: (product, qty = 1) => {
     const existing = get().items.find(i => i.product.id === product.id);
     if (existing) {
       set(s => ({
         items: s.items.map(i =>
-          i.product.id === product.id ? { ...i, quantity: i.quantity + 1 } : i
+          i.product.id === product.id ? { ...i, quantity: i.quantity + qty } : i
         )
       }));
     } else {
-      set(s => ({ items: [...s.items, { product, quantity: 1 }] }));
+      set(s => ({ items: [...s.items, { product, quantity: qty }] }));
     }
   },
 


### PR DESCRIPTION
## Summary
- Adds quantity stepper (− qty +) to each product card
- Fly-to-cart dot animation on Add — small dot flies from button to cart icon
- Cart sidebar no longer opens automatically on add
- Out-of-stock cards hide the stepper and disable the Add button

## Related issue
Closes #3

## Changes
- `ProductCard.tsx` — quantity stepper, flyToCart animation, refactored out-of-stock state
- `cartStore.ts` — addItem now accepts quantity
- `Navbar.tsx` — cart icon has `id="cart-icon-btn"` for animation targeting
- `Program.cs` — connection string parsing improvements

## Test plan
- [x] Add a product — dot animates to cart icon, sidebar stays closed
- [x] Stepper respects stock limit (+ disabled at max)
- [x] Out-of-stock products show disabled Add, no stepper
- [x] Cart badge updates correctly after adding

🤖 Generated with [Claude Code](https://claude.com/claude-code)
